### PR TITLE
OS-52 Enable support for digital signature sign cum verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,118 +84,130 @@ The type would have to be supplied as "type enum('MASTER', 'OTHER')" in Mysql.
     }' "http://localhost:8013/decrypt/obj"
  
 ### Sign
-    Sign a single attribute
+#### Sign a single attribute
     `curl -X POST -H "Content-Type: application/json" -d '{
       "value":"sunbird"
-    }' "http://localhost:8013/sign"
-    Sample response:
-    {
-        "signatureValue": "v1|2|PKCS1|vJUolu7lKXa2Jwba0VS8xPDbRUnPdyaIFe9fhPd8+fAybY3dJmiupMcI2VHlOhOWCT5+347PgPix8nn5hrs3Aw==",
-        "keyId": 2
+    }' "http://localhost:8013/sign"`
+*Sample response*
+    `{
+        "signatureValue": "vJUolu7lKXa2Jwba0VS8xPDbRUnPdyaIFe9fhPd8+fAybY3dJmiupMcI2VHlOhOWCT5+347PgPix8nn5hrs3Aw==",
+        "keyId": 2,
+        "version": "1.0.0"
     }
     `
     
-    Sign multiple attributes at one go
+#### Sign multiple attributes at one go
     `curl -X POST -H "Content-Type: application/json" -d '{
         "value": ["Ramesh Kumar", "9901990101"]
        }
-    }' "http://localhost:8013/sign"
-    Sample response:
-    [{
-        "signatureValue": "v1|2|PKCS1|Zof/AJu/ALQtD0OjuBFvs8dsZ/OfD08mC30ex5g1P1jV0IJYIHPscF0jGdGec/KkHmyvKkLU/hHiQ0czzr6Cvg==",
-        "keyId": 2
+    }' "http://localhost:8013/sign"`
+*Sample response*
+    `[{
+        "signatureValue": "Zof/AJu/ALQtD0OjuBFvs8dsZ/OfD08mC30ex5g1P1jV0IJYIHPscF0jGdGec/KkHmyvKkLU/hHiQ0czzr6Cvg==",
+        "keyId": 2,
+        "version": "1.0.0"
     },
     {
-        "signatureValue": "v1|3|PKCS1|tV0EHm0wKclS6v/gOhhaP51QcV39wUYPxYZCoA+4cGM2NicFGtjdMnV23HxZUR0CVxpVo91qBKeHbgpAD3/7pQ==",
-        "keyId": 3
+        "signatureValue": "tV0EHm0wKclS6v/gOhhaP51QcV39wUYPxYZCoA+4cGM2NicFGtjdMnV23HxZUR0CVxpVo91qBKeHbgpAD3/7pQ==",
+        "keyId": 3,
+        "version": "1.0.0"
     }]`
 
-    Sign a single entity
+#### Sign a single entity
     `curl -X POST -H "Content-Type: application/json" -d '{
        "entity": {
            "name": "Kevin", "phone": "9901990103" 
         } 
-    }' "http://localhost:8013/sign"
-    Sample response:
-    {
-        "signatureValue": "v1|2|PKCS1|iv07RbttVQZeOpGF8SCJitPnV/sEWW0LN8hc2U2MDMcIw3INsp5c8mjJiyiKvO31lS7LEflj20EOVvRmI3cRyw==",
-        "keyId": 2
+    }' "http://localhost:8013/sign"`
+*Sample response*
+    `{
+        "signatureValue": "iv07RbttVQZeOpGF8SCJitPnV/sEWW0LN8hc2U2MDMcIw3INsp5c8mjJiyiKvO31lS7LEflj20EOVvRmI3cRyw==",
+        "keyId": 2,
+        "version": "1.0.0"
     }`
 
-    Sign multiple entities
+#### Sign multiple entities
     `curl -X POST -H "Content-Type: application/json" -d '{
        "entity": [  
                 {"name": "Ram", "phone": "9901990101" }, 
                 {"name": "John", "phone": "9901990102" }
         ]
-    }' "http://localhost:8013/sign"
-    Sample response:
-    [{
-        "signatureValue": "v1|3|PKCS1|YzlNSN++9wFO7hBEXLgM3wBqWnCOi/euSyrbFSigrQe+t+ZwB0VNLfWGWdjwY8v28JTmns7T5cEArOcXeuqDbQ==",
-        "keyId": 3
+    }' "http://localhost:8013/sign"`
+*Sample response*
+    `[{
+        "signatureValue": "YzlNSN++9wFO7hBEXLgM3wBqWnCOi/euSyrbFSigrQe+t+ZwB0VNLfWGWdjwY8v28JTmns7T5cEArOcXeuqDbQ==",
+        "keyId": 3,
+        "version": "1.0.0"
     },
     {
-        "signatureValue": "v1|3|PKCS1|oVYESGSI3C2Bc/gt+PjddJmmAPd7Eo+sPJ6FUzUw6FBlylAaShOYrpXqQbbsSLx3IkPwVYdfIgo5Y/ZatU8WyA==",
-        "keyId": 3
+        "signatureValue": "oVYESGSI3C2Bc/gt+PjddJmmAPd7Eo+sPJ6FUzUw6FBlylAaShOYrpXqQbbsSLx3IkPwVYdfIgo5Y/ZatU8WyA==",
+        "keyId": 3,
+        "version": "1.0.0"
     }]`
 
 ### Verify
-    Verify a single attribute
+#### Verify a single attribute
     `curl -X POST -H "Content-Type: application/json" -d '{
       "value":{ 
             "claim": "sunbird",
-            "signatureValue": "v1|2|PKCS1|vJUolu7lKXa2Jwba0VS8xPDbRUnPdyaIFe9fhPd8+fAybY3dJmiupMcI2VHlOhOWCT5+347PgPix8nn5hrs3Aw=="
+            "signatureValue": "vJUolu7lKXa2Jwba0VS8xPDbRUnPdyaIFe9fhPd8+fAybY3dJmiupMcI2VHlOhOWCT5+347PgPix8nn5hrs3Aw==",
+            "keyId": 2
       }
-    }' "http://localhost:8013/verify"
-    Sample response:
-    true
-    `
+    }' "http://localhost:8013/verify"` 
+*Sample response*
+    `true`
     
-    Verify multiple attributes at one go
+    
+#### Verify multiple attributes at one go
     `curl -X POST -H "Content-Type: application/json" -d '{
         "value": [{
                 "claim": "Ramesh Kumar",
-                "signatureValue": "v1|2|PKCS1|Zof/AJu/ALQtD0OjuBFvs8dsZ/OfD08mC30ex5g1P1jV0IJYIHPscF0jGdGec/KkHmyvKkLU/hHiQ0czzr6Cvg=="
+                "signatureValue": "Zof/AJu/ALQtD0OjuBFvs8dsZ/OfD08mC30ex5g1P1jV0IJYIHPscF0jGdGec/KkHmyvKkLU/hHiQ0czzr6Cvg==",
+                "keyId": 2
             }, {
                 "claim": "9901990101",
-                "signatureValue": "v1|3|PKCS1|tV0EHm0wKclS6v/gOhhaP51QcV39wUYPxYZCoA+4cGM2NicFGtjdMnV23HxZUR0CVxpVo91qBKeHbgpAD3/7pQ=="
+                "signatureValue": "tV0EHm0wKclS6v/gOhhaP51QcV39wUYPxYZCoA+4cGM2NicFGtjdMnV23HxZUR0CVxpVo91qBKeHbgpAD3/7pQ==",
+                "keyId": 3
         ]
-    }' "http://localhost:8013/verify"
-    Sample response:
-    [
+    }' "http://localhost:8013/verify"` 
+*Sample response*
+    `[
         true,
         true
     ]`
 
-    Verify a single entity
+#### Verify a single entity
     `curl -X POST -H "Content-Type: application/json" -d '{
        "entity": {
            "claim": {"name": "fruit", "color": "red"},
-	        "signatureValue": "v1|3|PKCS1|qsBPIU0EN1+I+5LkjhPbxjQuWPKQIfkhCrP9mwchqdufhnnteOHOL0ZZfsbg8AgTVqTHNuvY7RYMfN2+d0wtvw==" 
+	        "signatureValue": "qsBPIU0EN1+I+5LkjhPbxjQuWPKQIfkhCrP9mwchqdufhnnteOHOL0ZZfsbg8AgTVqTHNuvY7RYMfN2+d0wtvw==",
+            "keyId": 2
         } 
-    }' "http://localhost:8013/verify"
-    Sample response:
-    true`
+    }' "http://localhost:8013/verify"` 
+*Sample response*
+    `true`
 
-    Verify multiple entities
+#### Verify multiple entities
     `curl -X POST -H "Content-Type: application/json" -d '{
        "entity":[{
 	        "claim": {"name": "fruit", "color": "red"},
-	        "signatureValue": "v1|3|PKCS1|qsAPIU0EN1+I+5LkjhPbxjQuWPKQIfkhCrP9mwchqdufhnnteOHOL0ZZfsbg8AgTVqTHNuvY7RYMfN2+d0wtvw=="
+	        "signatureValue": "qsAPIU0EN1+I+5LkjhPbxjQuWPKQIfkhCrP9mwchqdufhnnteOHOL0ZZfsbg8AgTVqTHNuvY7RYMfN2+d0wtvw==",
+            "keyId": 2
         },{
 	        "claim":{"name": "apple", "shape": "round"},
-	        "signatureValue": "v1|2|PKCS1|X87ErciD6X6bFBYUjZ0gd88BtuOWBbGe6iS1Rx2dVuKkYpkVXU/OaGXJv68AaZaTNsDPVbKVbBQx5t6oLlq+Uw=="
+	        "signatureValue": "X87ErciD6X6bFBYUjZ0gd88BtuOWBbGe6iS1Rx2dVuKkYpkVXU/OaGXJv68AaZaTNsDPVbKVbBQx5t6oLlq+Uw==",
+            "keyId": 3
         }]
-    }' "http://localhost:8013/verify"
-    Sample response:
-    [
+    }' "http://localhost:8013/verify"`
+*Sample response*
+    `[
         false,
         true
     ]`
 
 # Get keys
-    Get an active public key associated with the given identifier
-     `curl -X GET -H "Content-Type: application/json" "http://localhost:8013/keys/3"
-    Sample response:
-    -----BEGIN PUBLIC KEY-----MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBANNCNWC5K484XsQEvSL8rkVtJlAV9nTsusuHbxiU5xKp7R5Pw2ueEteqwfgRri0sVzJrrI394Tn/FjyXDtW+dhsCAwEAAQ==-----END PUBLIC KEY-----
+Get an active public key associated with the given identifier
+     `curl -X GET -H "Content-Type: application/json" "http://localhost:8013/keys/3"`
+*Sample response*
+    `-----BEGIN PUBLIC KEY-----MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBANNCNWC5K484XsQEvSL8rkVtJlAV9nTsusuHbxiU5xKp7R5Pw2ueEteqwfgRri0sVzJrrI394Tn/FjyXDtW+dhsCAwEAAQ==-----END PUBLIC KEY-----
     `

--- a/README.md
+++ b/README.md
@@ -197,7 +197,5 @@ The type would have to be supplied as "type enum('MASTER', 'OTHER')" in Mysql.
     Get an active public key associated with the given identifier
      `curl -X GET -H "Content-Type: application/json" "http://localhost:8013/keys/3"
     Sample response:
-    -----BEGIN PUBLIC KEY-----
-MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBANNCNWC5K484XsQEvSL8rkVtJlAV9nTsusuHbxiU5xKp7R5Pw2ueEteqwfgRri0sVzJrrI394Tn/FjyXDtW+dhsCAwEAAQ==
------END PUBLIC KEY-----
+    -----BEGIN PUBLIC KEY-----MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBANNCNWC5K484XsQEvSL8rkVtJlAV9nTsusuHbxiU5xKp7R5Pw2ueEteqwfgRri0sVzJrrI394Tn/FjyXDtW+dhsCAwEAAQ==-----END PUBLIC KEY-----
     `

--- a/README.md
+++ b/README.md
@@ -14,14 +14,16 @@ HTTP based Encryption Service.
 `npm i`
 
 ### DB Setup
+The following are instructions that works as-is in Postgres. For Mysql, there are some
+changes needed, as noted in each step.
 
 * Creating key type enum
-
-      CREATE TYPE "enum_Keys_type" AS ENUM ('MASTER','OTHER');
+    `CREATE TYPE "enum_Keys_type" AS ENUM ('MASTER','OTHER');`
+Not required in Mysql
 
 * Creating DB Table
 
-      CREATE TABLE "Keys" (
+      `CREATE TABLE "Keys" (
         id SERIAL PRIMARY KEY,
         public text NOT NULL,
         private text NOT NULL,
@@ -29,7 +31,8 @@ HTTP based Encryption Service.
         active boolean DEFAULT true NOT NULL,
         "createdAt" timestamp with time zone NOT NULL,
         "updatedAt" timestamp with time zone NOT NULL
-      );
+      );`
+The type would have to be supplied as "type enum('MASTER', 'OTHER')" in Mysql.
 
 ### Generating keys
 
@@ -80,3 +83,64 @@ HTTP based Encryption Service.
                  "phone": "v1|77|DL6oW2QemDz/qmPcqP+mjD5x6Y6d2GGYkfeUHqyk9qazJ5O7Ep4bH06VX0D3iqQjckESFMXlE9nBDcy93JFVNw=="}
     }' "http://localhost:8013/decrypt/obj"
  
+### Sign
+    Sign a single attribute
+    `curl -X POST -H "Content-Type: application/json" -d '{
+      "value":"sunbird"
+    }' "http://localhost:8013/sign"
+    Sample response:
+    {
+        "signatureValue": "v1|2|PKCS1|vJUolu7lKXa2Jwba0VS8xPDbRUnPdyaIFe9fhPd8+fAybY3dJmiupMcI2VHlOhOWCT5+347PgPix8nn5hrs3Aw==",
+        "keyId": 2
+    }
+    `
+    
+    Sign multiple attributes at one go
+    `curl -X POST -H "Content-Type: application/json" -d '{
+        "value": ["Ramesh Kumar", "9901990101"]
+       }
+    }' "http://localhost:8013/sign"
+    Sample response:
+    [
+    {
+        "signatureValue": "v1|2|PKCS1|Zof/AJu/ALQtD0OjuBFvs8dsZ/OfD08mC30ex5g1P1jV0IJYIHPscF0jGdGec/KkHmyvKkLU/hHiQ0czzr6Cvg==",
+        "keyId": 2
+    },
+    {
+        "signatureValue": "v1|3|PKCS1|tV0EHm0wKclS6v/gOhhaP51QcV39wUYPxYZCoA+4cGM2NicFGtjdMnV23HxZUR0CVxpVo91qBKeHbgpAD3/7pQ==",
+        "keyId": 3
+    }
+    ]`
+
+    Sign a single entity
+    `curl -X POST -H "Content-Type: application/json" -d '{
+       "entity": {
+           "name": "Kevin", "phone": "9901990103" 
+        } 
+    }' "http://localhost:8013/sign"
+    Sample response:
+    {
+        "signatureValue": "v1|2|PKCS1|iv07RbttVQZeOpGF8SCJitPnV/sEWW0LN8hc2U2MDMcIw3INsp5c8mjJiyiKvO31lS7LEflj20EOVvRmI3cRyw==",
+        "keyId": 2
+    }`
+
+    Sign multiple entities
+    `curl -X POST -H "Content-Type: application/json" -d '{
+       "entity": [  
+                {"name": "Ram", "phone": "9901990101" }, 
+                {"name": "John", "phone": "9901990102" }
+        ]
+    }' "http://localhost:8013/sign"
+    Sample response:
+    [
+    {
+        "signatureValue": "v1|3|PKCS1|YzlNSN++9wFO7hBEXLgM3wBqWnCOi/euSyrbFSigrQe+t+ZwB0VNLfWGWdjwY8v28JTmns7T5cEArOcXeuqDbQ==",
+        "keyId": 3
+    },
+    {
+        "signatureValue": "v1|3|PKCS1|oVYESGSI3C2Bc/gt+PjddJmmAPd7Eo+sPJ6FUzUw6FBlylAaShOYrpXqQbbsSLx3IkPwVYdfIgo5Y/ZatU8WyA==",
+        "keyId": 3
+    }
+    ]`
+
+### Verify

--- a/README.md
+++ b/README.md
@@ -101,16 +101,14 @@ The type would have to be supplied as "type enum('MASTER', 'OTHER')" in Mysql.
        }
     }' "http://localhost:8013/sign"
     Sample response:
-    [
-    {
+    [{
         "signatureValue": "v1|2|PKCS1|Zof/AJu/ALQtD0OjuBFvs8dsZ/OfD08mC30ex5g1P1jV0IJYIHPscF0jGdGec/KkHmyvKkLU/hHiQ0czzr6Cvg==",
         "keyId": 2
     },
     {
         "signatureValue": "v1|3|PKCS1|tV0EHm0wKclS6v/gOhhaP51QcV39wUYPxYZCoA+4cGM2NicFGtjdMnV23HxZUR0CVxpVo91qBKeHbgpAD3/7pQ==",
         "keyId": 3
-    }
-    ]`
+    }]`
 
     Sign a single entity
     `curl -X POST -H "Content-Type: application/json" -d '{
@@ -132,15 +130,74 @@ The type would have to be supplied as "type enum('MASTER', 'OTHER')" in Mysql.
         ]
     }' "http://localhost:8013/sign"
     Sample response:
-    [
-    {
+    [{
         "signatureValue": "v1|3|PKCS1|YzlNSN++9wFO7hBEXLgM3wBqWnCOi/euSyrbFSigrQe+t+ZwB0VNLfWGWdjwY8v28JTmns7T5cEArOcXeuqDbQ==",
         "keyId": 3
     },
     {
         "signatureValue": "v1|3|PKCS1|oVYESGSI3C2Bc/gt+PjddJmmAPd7Eo+sPJ6FUzUw6FBlylAaShOYrpXqQbbsSLx3IkPwVYdfIgo5Y/ZatU8WyA==",
         "keyId": 3
-    }
-    ]`
+    }]`
 
 ### Verify
+    Verify a single attribute
+    `curl -X POST -H "Content-Type: application/json" -d '{
+      "value":{ 
+            "claim": "sunbird",
+            "signatureValue": "v1|2|PKCS1|vJUolu7lKXa2Jwba0VS8xPDbRUnPdyaIFe9fhPd8+fAybY3dJmiupMcI2VHlOhOWCT5+347PgPix8nn5hrs3Aw=="
+      }
+    }' "http://localhost:8013/verify"
+    Sample response:
+    true
+    `
+    
+    Verify multiple attributes at one go
+    `curl -X POST -H "Content-Type: application/json" -d '{
+        "value": [{
+                "claim": "Ramesh Kumar",
+                "signatureValue": "v1|2|PKCS1|Zof/AJu/ALQtD0OjuBFvs8dsZ/OfD08mC30ex5g1P1jV0IJYIHPscF0jGdGec/KkHmyvKkLU/hHiQ0czzr6Cvg=="
+            }, {
+                "claim": "9901990101",
+                "signatureValue": "v1|3|PKCS1|tV0EHm0wKclS6v/gOhhaP51QcV39wUYPxYZCoA+4cGM2NicFGtjdMnV23HxZUR0CVxpVo91qBKeHbgpAD3/7pQ=="
+        ]
+    }' "http://localhost:8013/verify"
+    Sample response:
+    [
+        true,
+        true
+    ]`
+
+    Verify a single entity
+    `curl -X POST -H "Content-Type: application/json" -d '{
+       "entity": {
+           "claim": {"name": "fruit", "color": "red"},
+	        "signatureValue": "v1|3|PKCS1|qsBPIU0EN1+I+5LkjhPbxjQuWPKQIfkhCrP9mwchqdufhnnteOHOL0ZZfsbg8AgTVqTHNuvY7RYMfN2+d0wtvw==" 
+        } 
+    }' "http://localhost:8013/verify"
+    Sample response:
+    true`
+
+    Verify multiple entities
+    `curl -X POST -H "Content-Type: application/json" -d '{
+       "entity":[{
+	        "claim": {"name": "fruit", "color": "red"},
+	        "signatureValue": "v1|3|PKCS1|qsAPIU0EN1+I+5LkjhPbxjQuWPKQIfkhCrP9mwchqdufhnnteOHOL0ZZfsbg8AgTVqTHNuvY7RYMfN2+d0wtvw=="
+        },{
+	        "claim":{"name": "apple", "shape": "round"},
+	        "signatureValue": "v1|2|PKCS1|X87ErciD6X6bFBYUjZ0gd88BtuOWBbGe6iS1Rx2dVuKkYpkVXU/OaGXJv68AaZaTNsDPVbKVbBQx5t6oLlq+Uw=="
+        }]
+    }' "http://localhost:8013/verify"
+    Sample response:
+    [
+        false,
+        true
+    ]`
+
+# Get keys
+    Get an active public key associated with the given identifier
+     `curl -X GET -H "Content-Type: application/json" "http://localhost:8013/keys/3"
+    Sample response:
+    -----BEGIN PUBLIC KEY-----
+MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBANNCNWC5K484XsQEvSL8rkVtJlAV9nTsusuHbxiU5xKp7R5Pw2ueEteqwfgRri0sVzJrrI394Tn/FjyXDtW+dhsCAwEAAQ==
+-----END PUBLIC KEY-----
+    `

--- a/app.js
+++ b/app.js
@@ -45,7 +45,7 @@ initMiddlewares = () => {
 };
 
 initRoutes = () => {
-  app.get("/", (req, res) => {
+  app.get("/", (req, res) => {   
     return res.send("UP");
   });
 
@@ -146,9 +146,7 @@ const decryptValue = (value) => {
 const signValue = (value) => {
   let key = getKey();
   let signedVal = signatureUtils.rsaHashAndSign(value,config.hashAlgorithm,key.private);
-  let responseSignedVal = config.version+"|"+key.id+"|"+config.scheme+"|"+signedVal;
-
-  let result = new signatureResponse(responseSignedVal, key.id);
+  let result = new signatureResponse(signedVal, key.id, config.version);
   return result;
 };
 
@@ -165,18 +163,15 @@ const signMultipleEntities = (value) => {
 };
 
 const verifyValue = (obj) => {
+  let keyId = obj['keyId']
   let signatureValue = obj['signatureValue']
   let claim = obj['claim']
   if (typeof(claim) === 'object') {
     claim = JSON.stringify(claim)
   }
   
-  console.log("object = " + claim )
-  console.log("sign = " + signatureValue)
-  
-  let values = signatureValue.split("|");
-  let key = getKeyById(values[1]);
-  return signatureUtils.rsaHashAndVerify(values[3], new buffer(claim.trim()).toString("base64"), config.hashAlgorithm, key.public);
+  let key = getKeyById(keyId);
+  return signatureUtils.rsaHashAndVerify(signatureValue, new buffer(claim.trim()).toString("base64"), config.hashAlgorithm, key.public);
 };
 
 const verifyMultipleValues = (values) => {

--- a/app.js
+++ b/app.js
@@ -48,6 +48,11 @@ initRoutes = () => {
   app.get("/", (req, res) => {
     return res.send("UP");
   });
+
+  // Get public key specified by id
+  app.get("/keys/:id", (req, res) => {
+    return res.send(getPublicKey(req.params.id));
+  });
   
   // Encryption, Decryption
   app.post("/encrypt", (req, res) => {
@@ -105,6 +110,19 @@ const getKey = () => {
 const getKeyById = (keyId) => {
   return R.filter(key=>key.id==keyId,keyPairs)[0];
 };
+
+/** 
+ * Returns only active public keys 
+ * @param {number} keyId 
+ * */
+const getPublicKey = (keyId) => {
+  let key = getKeyById(keyId);
+  let publicKey = "";
+  if (key && key.active) {
+    publicKey = '-----BEGIN PUBLIC KEY-----\n' + key.public + '\n' + '-----END PUBLIC KEY-----';
+  }
+  return publicKey;
+}
 
 const encryptObj = (obj) => {
   return R.map(encryptValue, obj);

--- a/classes/signResponse.js
+++ b/classes/signResponse.js
@@ -1,0 +1,11 @@
+/**
+ * Response to signature generation APIs
+ */
+class SignatureResponse {
+    constructor(signedValue, key) {
+        this.signatureValue = signedValue
+        this.keyId = key
+    }
+}
+
+module.exports = SignatureResponse

--- a/classes/signResponse.js
+++ b/classes/signResponse.js
@@ -2,9 +2,10 @@
  * Response to signature generation APIs
  */
 class SignatureResponse {
-    constructor(signedValue, key) {
+    constructor(signedValue, key, version) {
         this.signatureValue = signedValue
         this.keyId = key
+        this.version = version
     }
 }
 

--- a/config/config.js
+++ b/config/config.js
@@ -10,7 +10,7 @@ const config = {
       max:300
     },
     "scheme":"PKCS1",
-    "version":"v1",
+    "version":"1.0.0",
     "hashAlgorithm": "sha256"
   },
   "prod": {
@@ -24,7 +24,7 @@ const config = {
       max:300
     },
     "scheme":"PKCS1",
-    "version":"v1",
+    "version":"1.0.0",
     "hashAlgorithm": "sha256"
   }
 }

--- a/config/config.js
+++ b/config/config.js
@@ -10,7 +10,8 @@ const config = {
       max:300
     },
     "scheme":"PKCS1",
-    "version":"v1"
+    "version":"v1",
+    "hashAlgorithm": "sha256"
   },
   "prod": {
     "username": process.env.DB_USER,
@@ -23,7 +24,8 @@ const config = {
       max:300
     },
     "scheme":"PKCS1",
-    "version":"v1"
+    "version":"v1",
+    "hashAlgorithm": "sha256"
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "enc-service",
-  "version": "1.2.0",
+  "version": "1.1.0",
   "description": "Supports encryption, decryption and signing, verification",
   "main": "app.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "enc-service",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Supports encryption, decryption and signing, verification",
   "main": "app.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "enc-service",
-  "version": "1.0.0",
-  "description": "",
+  "version": "1.1.0",
+  "description": "Supports encryption, decryption and signing, verification",
   "main": "app.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/utils/signatureUtils.js
+++ b/utils/signatureUtils.js
@@ -1,0 +1,33 @@
+const crypto = require("crypto");
+const ursa = require("ursa");
+const R = require("ramda");
+
+/**
+ * Adds a 16 bit length salt and creates a base64 encoded signature.
+ * Increasing the salt length could potentially cause "data too large to sign 
+ * message" as the data is variant. Test with typical payload before change
+ * @param {string} message Message to be signed
+ * @param {string} hashAlgo Any dgst algo, such as sha256, sha512, sha, sha1
+ * @param {string} privateKey 
+ * @returns {string} base64 encoded signature string
+ */
+const rsaHashAndSign = (message, hashAlgo, privateKey) => {
+  var crt = ursa.createPrivateKey('-----BEGIN RSA PRIVATE KEY-----\n' + privateKey + '\n' + '-----END RSA PRIVATE KEY-----')
+  return crt.hashAndSign(hashAlgo, message, 'utf8', 'base64', false, 0);  
+}
+
+/**
+ * Verifies if the signed message is same as original.
+ * @param {string} signature Signed message
+ * @param {string} claim Original message
+ * @param {string} hashAlgo Any dgst algo, such as sha256, sha512, sha, sha1
+ * @param {string} publicKey 
+ * @returns true if signature matches the original message, false otherwise
+ */
+const rsaHashAndVerify = (signature, claim, hashAlgo, publicKey) => {
+  var crt = ursa.createPublicKey('-----BEGIN PUBLIC KEY-----\n' + publicKey + '\n' + '-----END PUBLIC KEY-----')
+  return crt.hashAndVerify(hashAlgo, claim, signature, 'base64', false, 16);  
+}
+
+exports.rsaHashAndSign = rsaHashAndSign;
+exports.rsaHashAndVerify = rsaHashAndVerify;

--- a/utils/signatureUtils.js
+++ b/utils/signatureUtils.js
@@ -13,7 +13,7 @@ const R = require("ramda");
  */
 const rsaHashAndSign = (message, hashAlgo, privateKey) => {
   var crt = ursa.createPrivateKey('-----BEGIN RSA PRIVATE KEY-----\n' + privateKey + '\n' + '-----END RSA PRIVATE KEY-----')
-  return crt.hashAndSign(hashAlgo, message, 'utf8', 'base64', false, 0);  
+  return crt.hashAndSign(hashAlgo, message, 'utf8', 'base64', true, 16);  
 }
 
 /**
@@ -26,7 +26,7 @@ const rsaHashAndSign = (message, hashAlgo, privateKey) => {
  */
 const rsaHashAndVerify = (signature, claim, hashAlgo, publicKey) => {
   var crt = ursa.createPublicKey('-----BEGIN PUBLIC KEY-----\n' + publicKey + '\n' + '-----END PUBLIC KEY-----')
-  return crt.hashAndVerify(hashAlgo, claim, signature, 'base64', false, 16);  
+  return crt.hashAndVerify(hashAlgo, claim, signature, 'base64', true, 16); 
 }
 
 exports.rsaHashAndSign = rsaHashAndSign;


### PR DESCRIPTION
As part of consent drive architecture, this service is enhanced with three additional APIs, namely,
/sign
/verify
/keys/:id

A user can sign/verify single value, array of values, single entity and multiple entities at one go. The response contains a key identifier, using which any verification party can retrieve the public key.

This service would take in the value portion of the attribute and sign that, not the attribute name (since it may be subjected to change anytime). Also, note that the service doesn't even take the attribute name as input. When it signs the whole entity, it is expected that the entity doesn't change, which includes attribute name and values.

sha256 hashing technique is defaulted to (any other openssl dgst algorithms can be used as well).
16 bit salt is added and due to which the same value would return different signature values upon repeated executions.
The service version is tagged as 1.1.0 and the payload version is 1.0.0 still. 

In case of signing multiple values together as a batch, the response is not having any detail on input. It is left as a positional index to retrieve the appropriate result (burden on the invoker). The incoming input could not become an object as it itself could be a simple value or an object. So option would be to create an index, which is best avoided in total. Hence, not changing that (also note this is same as encrypt or decrypt batch operations).

_Note to reviewers:_
1. Look at readme for quick understanding of the changes proposed.
2. Request reviewer to go commit by commit while doing review, as I've grouped the changes to a meaningful set in that granularity.

**Testing**
The samples provided in the README were provided from testing.