### PR TITLE
OS#62 Add ability to start service from env var password

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ The type would have to be supplied as "type enum('MASTER', 'OTHER')" in Mysql.
 
  This will start the encryption service in the background on port 8013 by reading the master password from `passwd` file.
 
+#### Run the service without passwd file
+Export an environment variable `ENTRY_PASS` holding the master password and start the service as given below
+    node app.js &
 
 ## APIs
 ### Encrypt

--- a/app.js
+++ b/app.js
@@ -68,7 +68,6 @@ initRoutes = () => {
     return res.send(decryptObj(req.body.value));
   });
 
-
   // Signature, Verification
   app.post("/sign", (req, res) => {
     if (Array.isArray(req.body.value)) {
@@ -218,14 +217,8 @@ loadKeysFromDB = () => {
 };
 
 getMasterPassword = (resolve,reject) => {
-  prompt.start()
-  prompt.get(schema, function(err, result) {
-    if (err) {
-      return reject(err);
-    }
-    password = result.password;
-    resolve(password);
-  });
+  password = process.env.ENTRY_PASS;
+  resolve(password);
 };
 
 getPassword = () => {


### PR DESCRIPTION
The devops team needs ability to start the service from env var and not from the password file. So earlier method of scripted start `node app.js < passwd` doesn't seem to help in the dockerized container world.