### PR TITLE
:bug: outdated node base image tag updated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6.14.4
+FROM node:8-buster
 MAINTAINER "S M Y ALTAMASH" "smy.altamash@gmail.com"
 WORKDIR /home/enc
 COPY . /home/enc


### PR DESCRIPTION
this PR will fix the following docker build issue with outdated Debian node base image
```
docker build .
[+] Building 2.8s (8/8) FINISHED                                                                                                                                                                                                                => [internal] load .dockerignore                                                                                                                                                                                                         0.0s
 => => transferring context: 2B                                                                                                                                                                                                           0.0s
 => [internal] load build definition from Dockerfile                                                                                                                                                                                      0.0s
 => => transferring dockerfile: 366B                                                                                                                                                                                                      0.0s
 => [internal] load metadata for docker.io/library/node:6.14.4                                                                                                                                                                            1.0s
 => [1/4] FROM docker.io/library/node:6.14.4@sha256:2495d0c571aa1232d4e70b00b2e496092521be966cfbbc585c1b7dacc8296ae1                                                                                                                      0.1s
 => => resolve docker.io/library/node:6.14.4@sha256:2495d0c571aa1232d4e70b00b2e496092521be966cfbbc585c1b7dacc8296ae1                                                                                                                      0.1s
 => [internal] load build context                                                                                                                                                                                                         0.1s
 => => transferring context: 3.86kB                                                                                                                                                                                                       0.0s
 => CACHED [2/4] WORKDIR /home/enc                                                                                                                                                                                                        0.0s
 => [3/4] COPY . /home/enc                                                                                                                                                                                                                0.2s
 => ERROR [4/4] RUN apt update     && apt install -y zip python make g++     && npm i     && apt remove --purge -y python make g++     && apt-get autoremove -y     && rm -rf /var/lib/apt/lists/*                                        1.4s
------                                                                                                                                                                                                                                         
 > [4/4] RUN apt update     && apt install -y zip python make g++     && npm i     && apt remove --purge -y python make g++     && apt-get autoremove -y     && rm -rf /var/lib/apt/lists/*:                                                   
#0 0.422                                                                                                                                                                                                                                       
#0 0.422 WARNING: apt does not have a stable CLI interface. Use with caution in scripts.                                                                                                                                                       
#0 0.422                                                                                                                                                                                                                                       
#0 0.634 Ign:1 http://security.debian.org/debian-security stretch/updates InRelease                                                                                                                                                            
#0 0.672 Ign:2 http://deb.debian.org/debian stretch InRelease
#0 0.687 Err:3 http://security.debian.org/debian-security stretch/updates Release
#0 0.687   404  Not Found
#0 0.867 Ign:4 http://deb.debian.org/debian stretch-updates InRelease
#0 1.037 Err:5 http://deb.debian.org/debian stretch Release
#0 1.037   404  Not Found
#0 1.276 Err:6 http://deb.debian.org/debian stretch-updates Release
#0 1.276   404  Not Found
#0 1.293 Reading package lists...
#0 1.341 E: The repository 'http://security.debian.org/debian-security stretch/updates Release' does not have a Release file.
#0 1.341 E: The repository 'http://deb.debian.org/debian stretch Release' does not have a Release file.
#0 1.341 E: The repository 'http://deb.debian.org/debian stretch-updates Release' does not have a Release file.
------
Dockerfile:5
--------------------
   4 |     COPY . /home/enc
   5 | >>> RUN apt update \
   6 | >>>     && apt install -y zip python make g++ \
   7 | >>>     && npm i \
   8 | >>>     && apt remove --purge -y python make g++ \
   9 | >>>     && apt-get autoremove -y \
  10 | >>>     && rm -rf /var/lib/apt/lists/*
  11 |     EXPOSE 8013
--------------------
ERROR: failed to solve: process "/bin/sh -c apt update     && apt install -y zip python make g++     && npm i     && apt remove --purge -y python make g++     && apt-get autoremove -y     && rm -rf /var/lib/apt/lists/*" did not complete successfully: exit code: 100
```

@santhosh-tg